### PR TITLE
feat: swagger 추가 및 로그인 주소 변경

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -58,6 +58,7 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8'
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/kr/end/backend/auth/controller/AuthController.java
+++ b/backend/src/main/java/kr/end/backend/auth/controller/AuthController.java
@@ -27,4 +27,11 @@ public class AuthController {
         return ResponseEntity.ok(authService.signupMember(request));
     }
 
+    @PostMapping("/login")
+    public ResponseEntity<MemberResponse> login(@Valid @RequestBody LoginRequest request) {
+        return ResponseEntity.ok().build();
+    }
+
+
+
 }

--- a/backend/src/main/java/kr/end/backend/auth/filter/LoginFilter.java
+++ b/backend/src/main/java/kr/end/backend/auth/filter/LoginFilter.java
@@ -30,7 +30,7 @@ import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 @Slf4j
 public class LoginFilter extends AbstractAuthenticationProcessingFilter {
 
-  private static final String LOGIN_REQUEST_URL = "/v1/login";
+  private static final String LOGIN_REQUEST_URL = "/v1/auth/login";
   private static final String LOGIN_REQUEST_HTTP_METHOD = "POST";
   private static final String LOGIN_REQUEST_CONTENT_TYPE = "application/json";
   private static final AntPathRequestMatcher DEFAULT_LOGIN_PATH_REQUEST_MATCHER =
@@ -63,7 +63,6 @@ public class LoginFilter extends AbstractAuthenticationProcessingFilter {
     }
 
     LoginRequest loginDto = parseDto(request);
-    log.info("loginDto: {}", loginDto);
     return getAuthentication(loginDto);
   }
 

--- a/backend/src/main/java/kr/end/backend/global/config/SwaggerConfig.java
+++ b/backend/src/main/java/kr/end/backend/global/config/SwaggerConfig.java
@@ -1,0 +1,22 @@
+package kr.end.backend.global.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+  @Bean
+  public OpenAPI openAPI() {
+    Info info = new Info()
+        .title("JJUST Backend API")
+        .version("1.0");
+
+    return new OpenAPI()
+        .components(new Components())
+        .info(info);
+  }
+}

--- a/backend/src/main/java/kr/end/backend/member/controller/MemberController.java
+++ b/backend/src/main/java/kr/end/backend/member/controller/MemberController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/v1/members")
 @RequiredArgsConstructor
-public class MemberController {
+public class MemberController implements MemberSwaggerController {
 
   private final MemberService memberService;
 

--- a/backend/src/main/java/kr/end/backend/member/controller/MemberSwaggerController.java
+++ b/backend/src/main/java/kr/end/backend/member/controller/MemberSwaggerController.java
@@ -1,0 +1,19 @@
+package kr.end.backend.member.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import kr.end.backend.auth.dto.response.MemberResponse;
+import kr.end.backend.member.domain.Member;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "MyInfo API")
+public interface MemberSwaggerController {
+
+  @Operation(summary = "내 정보 조회", responses = {
+      @ApiResponse(responseCode = "200", description = "내 정보 조회 성공", content = @Content(schema = @Schema(implementation = MemberResponse.class)))})
+  public ResponseEntity<MemberResponse> readUserInfo(@Parameter(hidden = true) Member member);
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - OpenAPI(Swagger) 문서 자동 생성 및 UI 제공 기능이 추가되었습니다.
  - 로그인용 POST 엔드포인트(`/login`)가 추가되었습니다.

- **문서화**
  - API 보안 및 메타데이터 설정을 포함한 Swagger(OpenAPI) 설정이 도입되었습니다.
  - 회원 정보 조회 API에 대한 Swagger 문서화 인터페이스가 추가되었습니다.

- **기타**
  - 로그인 요청 URL이 `/v1/login`에서 `/v1/auth/login`으로 변경되었습니다.
  - 회원 컨트롤러 클래스가 Swagger 문서화 인터페이스를 구현하도록 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->