### PR TITLE
feat: swagger 컨트롤러 분리 / 물품 관련 메소드 추가

### DIFF
--- a/backend/src/main/java/kr/end/backend/auth/controller/AuthController.java
+++ b/backend/src/main/java/kr/end/backend/auth/controller/AuthController.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/v1/auth")
 @RequiredArgsConstructor
-public class AuthController {
+public class AuthController implements AuthSwaggerController{
 
     private final AuthService authService;
 

--- a/backend/src/main/java/kr/end/backend/auth/controller/AuthSwaggerController.java
+++ b/backend/src/main/java/kr/end/backend/auth/controller/AuthSwaggerController.java
@@ -1,0 +1,23 @@
+package kr.end.backend.auth.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import kr.end.backend.auth.dto.request.LoginRequest;
+import kr.end.backend.auth.dto.request.SignupRequest;
+import kr.end.backend.member.dto.response.MemberResponse;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "회원 관련 API")
+public interface AuthSwaggerController {
+
+  @Operation(summary = "회원가입", responses = {
+      @ApiResponse(responseCode = "200", description = "회원가입 성공", content = @Content(schema = @Schema(implementation = MemberResponse.class)))})
+  public ResponseEntity<MemberResponse> signup(SignupRequest request);
+
+  @Operation(summary = "로그인", responses = {
+      @ApiResponse(responseCode = "200", description = "로그인 성공", content = @Content(schema = @Schema(implementation = MemberResponse.class)))})
+  public ResponseEntity<MemberResponse> login(LoginRequest request);
+}

--- a/backend/src/main/java/kr/end/backend/item/controller/ItemController.java
+++ b/backend/src/main/java/kr/end/backend/item/controller/ItemController.java
@@ -23,7 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/v1/items")
 @RequiredArgsConstructor
-public class ItemController {
+public class ItemController implements ItemSwaggerController {
 
   private final ItemService itemService;
 

--- a/backend/src/main/java/kr/end/backend/item/controller/ItemSwaggerController.java
+++ b/backend/src/main/java/kr/end/backend/item/controller/ItemSwaggerController.java
@@ -1,0 +1,42 @@
+package kr.end.backend.item.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import kr.end.backend.item.dto.request.ItemRequest;
+import kr.end.backend.item.dto.response.ItemResponse;
+import kr.end.backend.member.domain.Member;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "물품 관련 API")
+public interface ItemSwaggerController {
+
+  @Operation(summary = "물품 등록", responses = {
+      @ApiResponse(responseCode = "200", description = "물품 등록 성공",
+          content = @Content(schema = @Schema(implementation = ItemResponse.class)))})
+  public ResponseEntity<ItemResponse> createItem(@Parameter(hidden = true) Member member,
+      ItemRequest request);
+
+  @Operation(summary = "선택한 물품 조회", responses = {
+      @ApiResponse(responseCode = "200", description = "물품 조회 성공",
+          content = @Content(schema = @Schema(implementation = ItemResponse.class)))})
+  public ResponseEntity<ItemResponse> getItem(@Parameter(hidden = true) Member member, Long id);
+
+  @Operation(summary = "내 물품 전체 조회", responses = {
+      @ApiResponse(responseCode = "200", description = "물품 조회 성공",
+          content = @Content(schema = @Schema(implementation = ItemResponse[].class)))})
+  public ResponseEntity<List<ItemResponse>> getItems(@Parameter(hidden = true) Member member);
+
+  @Operation(summary = "선택한 물품 삭제", responses = {
+      @ApiResponse(responseCode = "200", description = "물품 삭제 성공")})
+  public ResponseEntity<Void> deleteItem(@Parameter(hidden = true) Member member, Long id);
+
+  @Operation(summary = "선택한 물품 수정", responses = {
+      @ApiResponse(responseCode = "200", description = "물품 수정 성공")})
+  public ResponseEntity<Void> updateItem(@Parameter(hidden = true) Member member, Long id,
+      ItemRequest request);
+}

--- a/backend/src/main/java/kr/end/backend/item/domain/Item.java
+++ b/backend/src/main/java/kr/end/backend/item/domain/Item.java
@@ -9,6 +9,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
 import kr.end.backend.global.BaseEntity;
 import kr.end.backend.member.domain.Member;
 import lombok.AccessLevel;
@@ -61,4 +62,38 @@ public class Item extends BaseEntity {
   }
 
 
+  public Integer getProfit() {
+    if (this.salePrice == null || this.purchasePrice == null) {
+      return null;
+    }
+    return this.salePrice - this.purchasePrice;
+  }
+
+  public Long getPeriodUse() {
+    if (this.saleDate == null || this.purchaseDate == null) {
+      return null;
+    }
+    return ChronoUnit.DAYS.between(this.purchaseDate, this.saleDate);
+  }
+
+  public Integer getDailyCost() {
+    if (this.saleDate == null) {
+      return null;
+    }
+    Integer profit = this.getProfit();
+    if (profit == null) {
+      return null;
+    }
+
+    Long period = this.getPeriodUse();
+    if (period == null) {
+      return null;
+    }
+
+    if (period == 0) {
+      period = 1L; // 당일 구매/판매의 경우 1일로 계산
+    }
+
+    return Math.toIntExact(profit / period);
+  }
 }

--- a/backend/src/main/java/kr/end/backend/item/dto/response/ItemResponse.java
+++ b/backend/src/main/java/kr/end/backend/item/dto/response/ItemResponse.java
@@ -11,8 +11,10 @@ public record ItemResponse(
     LocalDate purchaseDate,
     Integer salePrice,
     LocalDate saleDate,
-    String memo
-
+    String memo,
+    Integer profit,
+    Long periodUse,
+    Integer dailyCost
 ) {
 
 
@@ -24,7 +26,11 @@ public record ItemResponse(
         item.getPurchaseDate(),
         item.getSalePrice(),
         item.getSaleDate(),
-        item.getMemo());
+        item.getMemo(),
+        item.getProfit(),
+        item.getPeriodUse(),
+        item.getDailyCost()
+    );
   }
 }
 

--- a/backend/src/main/java/kr/end/backend/member/controller/MemberSwaggerController.java
+++ b/backend/src/main/java/kr/end/backend/member/controller/MemberSwaggerController.java
@@ -10,7 +10,7 @@ import kr.end.backend.auth.dto.response.MemberResponse;
 import kr.end.backend.member.domain.Member;
 import org.springframework.http.ResponseEntity;
 
-@Tag(name = "MyInfo API")
+@Tag(name = "내정보 API")
 public interface MemberSwaggerController {
 
   @Operation(summary = "내 정보 조회", responses = {


### PR DESCRIPTION
- 판매액 등록 시 차액 계산
- 판매날짜 등록 시 사용일수 및 일일 비용 계산

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 회원 인증 및 물품 관련 API에 Swagger 기반의 문서화가 추가되어, API 명세를 더욱 쉽게 확인할 수 있습니다.
    - 물품(Item) 응답에 이익(profit), 사용 기간(periodUse), 일일 비용(dailyCost) 정보가 추가되어, 구매·판매 내역의 재무 정보를 확인할 수 있습니다.

- **문서화**
    - API 문서의 태그명이 한글로 개선되어, Swagger UI에서 한글로 그룹화된 API를 확인할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->